### PR TITLE
fix: build 시 background.js 경로 문제를 상대경로로 수정 (#4)

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -16,7 +16,7 @@ export default defineConfig({
     viteStaticCopy({
       targets: [
         {
-          src: path.resolve(__dirname, "src/background/background.js"),
+          src: "src/background/background.js",
           dest: "background",
         },
       ],


### PR DESCRIPTION
## #️⃣ Issue Number #4 

## 📝 세부 내용

- `npm run build` 실행 시 `background.js`가 누락되는 문제가 있었습니다.
- 원인은 `vite.config.js`의 `viteStaticCopy` 설정에서 절대경로(`path.resolve(...)`)를 사용한 것이었고, 환경에 따라 파일이 제대로 복사되지 않았습니다.
- 이를 해결하기 위해 `src/background/background.js`를 **상대경로로 수정**하여 `vite-plugin-static-copy`가 안정적으로 작동하도록 변경했습니다.


## 💬 리뷰 요청 사항

- 현재 상대경로 설정이 윈도우 OS 및 개발 환경에서 문제 없이 작동할지 확인 부탁드립니다.
- `vite.config.js` 외에 해당 설정을 참조하는 다른 곳이 있는지도 검토해주시면 좋겠습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
