### PR TITLE
feat: Repository UI 구현 및 pages 폴더 구조 개편 (#7)

### DIFF
--- a/src/sidepanel/App.jsx
+++ b/src/sidepanel/App.jsx
@@ -1,7 +1,21 @@
+import { Routes, Route } from "react-router-dom";
+
 import MainPage from "@/sidepanel/pages/MainPage";
+import Repository from "@/sidepanel/pages/Repository";
 
 const App = () => {
-  return <MainPage />;
+  return (
+    <Routes>
+      <Route
+        path="/"
+        element={<MainPage />}
+      />
+      <Route
+        path="/repository"
+        element={<Repository />}
+      />
+    </Routes>
+  );
 };
 
 export default App;

--- a/src/sidepanel/components/BackButton.jsx
+++ b/src/sidepanel/components/BackButton.jsx
@@ -1,0 +1,11 @@
+import "@/styles/styles.css";
+
+const BackButton = () => {
+  return (
+    <div className="absolute top-0 left-0 mt-2 ml-3">
+      <button className="text-3xl text-black">&larr;</button>
+    </div>
+  );
+};
+
+export default BackButton;

--- a/src/sidepanel/main.jsx
+++ b/src/sidepanel/main.jsx
@@ -1,11 +1,11 @@
-import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { HashRouter } from "react-router-dom";
 
 import "@/styles/index.css";
 import App from "@/sidepanel/App.jsx";
 
 createRoot(document.getElementById("root")).render(
-  <StrictMode>
+  <HashRouter>
     <App />
-  </StrictMode>,
+  </HashRouter>,
 );

--- a/src/sidepanel/pages/MainPage/index.jsx
+++ b/src/sidepanel/pages/MainPage/index.jsx
@@ -1,4 +1,3 @@
-import React from "react";
 import "@/styles/styles.css";
 
 const MainPage = () => {

--- a/src/sidepanel/pages/Repository/index.jsx
+++ b/src/sidepanel/pages/Repository/index.jsx
@@ -1,0 +1,56 @@
+import "@/styles/styles.css";
+import { useState } from "react";
+
+import BackButton from "@/sidepanel/components/BackButton";
+
+const Repository = () => {
+  const [showMenu, setShowMenu] = useState(false);
+
+  return (
+    <div className="main-container relative">
+      <BackButton />
+      <div className="mb-6 flex justify-center">
+        <span className="text-3xl font-extrabold">저장소</span>
+      </div>
+
+      <div className="relative w-100 rounded-lg border border-gray-300 bg-white p-4 shadow-sm">
+        <div className="absolute -top-2 -left-2 rounded-full bg-orange-500 px-2 py-1 text-xs text-white shadow">
+          #1
+        </div>
+
+        <div className="mb-2 flex items-center justify-between">
+          <div className="font-bold text-stone-800">매뉴얼 제목 1</div>
+          <div className="relative">
+            <button
+              className="cursor-pointer text-xl text-gray-500"
+              onClick={() => setShowMenu(!showMenu)}
+            >
+              ⋯
+            </button>
+            {showMenu && (
+              <div className="absolute right-0 z-10 mt-2 w-24 rounded-md border bg-white shadow-md">
+                <button className="w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-gray-100">
+                  공유
+                </button>
+                <button className="w-full cursor-pointer px-3 py-2 text-left text-sm hover:bg-gray-100">
+                  수정
+                </button>
+                <button className="s w-full px-3 py-2 text-left text-sm text-red-500 hover:bg-red-50">
+                  삭제
+                </button>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="mb-3 text-sm text-gray-500">2025-04-29</div>
+
+        <div className="flex h-36 w-full items-center justify-center rounded-md bg-gray-200 text-sm text-gray-400">
+          썸네일 이미지
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Repository;


### PR DESCRIPTION
## #️⃣ Issue Number #7 

<!-- 예: #00 ##01 -->

## 📝 세부 내용

- 📁 pages/ 안에 있던 파일들을 페이지 단위로 폴더를 나눴어요.
예: MainPage/index.jsx, Repository/index.jsx

- 🧭 페이지 이동을 위해 HashRouter에 새 경로를 추가했어요.

- 🔙 여러 페이지에서 쓸 수 있는 뒤로가기 버튼 컴포넌트를 components/BackButton.jsx로 따로 뺐어요.

- 💾 새로운 Repository 화면 UI를 만들었고, 저장소 정보를 카드 형태로 보여줍니다.


## 💬 리뷰 요청 사항

- 페이지별로 디렉토리를 나눈 구조 괜찮은지 봐주세요!
- BackButton 컴포넌트 분리 방식에 문제 없는지도 확인 부탁드려요.
- 라우터에 페이지 추가한 방식도 함께 봐주시면 감사하겠습니다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
