### PR TITLE
feat: 화면 캡처 및 클릭 감지 로직 구현 (#16)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "manifest_version": 3,
 
-  "permissions": ["sidePanel","scripting", "activeTab"],
+  "permissions": ["sidePanel","scripting", "activeTab", "tabs"],
 
   "host_permissions": ["<all_urls>"],
 
@@ -19,13 +19,5 @@
 
   "side_panel": {
     "default_path": "src/sidepanel/index.html"
-  },
-
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "js": ["captureOverlay.js"],
-      "run_at": "document_idle"
-    }
-  ]
+  }
 }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,3 +1,40 @@
 chrome.runtime.onInstalled.addListener(() => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
 });
+
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === "START_CAPTURE") {
+    chrome.tabs.query({}, (tabs) => {
+      tabs.forEach((tab) => {
+        if (tab.id) {
+          chrome.scripting.insertCSS({
+            target: { tabId: tab.id },
+            files: ["style/style.css"],
+          });
+
+          chrome.scripting.executeScript({
+            target: { tabId: tab.id },
+            files: ["captureOverlay.js"],
+          });
+        }
+      });
+
+      sendResponse({ status: "content scripts injected to all tabs" });
+    });
+    return true;
+  }
+
+  if (message.type === "CLICKED") {
+    chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
+      if (chrome.runtime.lastError) {
+        console.error("Capture error:", chrome.runtime.lastError);
+        return;
+      }
+
+      chrome.runtime.sendMessage({
+        type: "CAPTURED_IMAGE",
+        image: dataUrl,
+      });
+    });
+  }
+});

--- a/src/content/captureOverlay.js
+++ b/src/content/captureOverlay.js
@@ -1,1 +1,17 @@
-alert("Capture overlay started");
+if (!window.captureOverlayExist) {
+  window.captureOverlayExist = true;
+
+  const notifyCaptureStart = () => {
+    const overlay = document.createElement("div");
+    overlay.textContent = "녹화가 시작되었습니다";
+    overlay.className = "recording-overlay";
+    document.body.appendChild(overlay);
+    setTimeout(() => overlay.remove(), 1500);
+  };
+
+  notifyCaptureStart();
+
+  window.addEventListener("click", () => {
+    chrome.runtime.sendMessage({ type: "CLICKED" });
+  });
+}

--- a/src/content/style/style.css
+++ b/src/content/style/style.css
@@ -1,0 +1,14 @@
+.recording-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background-color: rgba(0, 0, 0, 0.7);
+  color: white;
+  font-size: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 999999;
+}

--- a/src/sidepanel/pages/MainPage/index.jsx
+++ b/src/sidepanel/pages/MainPage/index.jsx
@@ -5,13 +5,7 @@ const MainPage = () => {
   const navigate = useNavigate();
 
   const handleStartClick = () => {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      const tabId = tabs[0]?.id;
-      if (tabId) {
-        chrome.scripting.executeScript({ files: ["captureOverlay.js"], target: { tabId } });
-        navigate("/taskboard");
-      }
-    });
+    navigate("/taskboard");
   };
   return (
     <div className="flex min-h-screen flex-col items-center justify-between bg-white pt-10 pb-12">

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -1,12 +1,35 @@
+import { useEffect, useState } from "react";
+
 const TaskBoard = () => {
-  const items = [{ id: 1, title: "제목(1)", image: "캡쳐사진" }];
+  const [images, setImages] = useState([]);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage({ type: "START_CAPTURE" }, () => {
+      if (chrome.runtime.lastError) {
+        console.error("START_CAPTURE 에러:", chrome.runtime.lastError);
+        return;
+      }
+    });
+
+    const handleMessage = (message) => {
+      if (message.type === "CAPTURED_IMAGE") {
+        setImages((prev) => [...prev, message.image]);
+      }
+    };
+
+    chrome.runtime.onMessage.addListener(handleMessage);
+
+    return () => {
+      chrome.runtime.onMessage.removeListener(handleMessage);
+    };
+  }, []);
 
   return (
     <div className="flex h-screen flex-col bg-white">
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
-        {items.map((item, index) => (
+        {images.map((image, index) => (
           <div
-            key={item.id}
+            key={index}
             className="space-y-2"
           >
             <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
@@ -14,14 +37,17 @@ const TaskBoard = () => {
                 <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
                   {index + 1}
                 </div>
-                <div className="font-bold">{item.title} ⋯</div>
+                <div className="font-bold">TEST TITLE ⋯</div>
               </div>
               <button className="text-lg text-red-500">⋯</button>
             </div>
             <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
-              {item.image}
+              <img
+                src={image}
+                className="max-h-full max-w-full object-contain"
+              />
             </div>
-            {index !== items.length - 1 && (
+            {index !== images.length - 1 && (
               <div className="flex justify-center text-2xl text-gray-400">↓</div>
             )}
           </div>
@@ -30,19 +56,19 @@ const TaskBoard = () => {
 
       <div className="flex justify-around bg-orange-500 py-4 text-white">
         <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-green-500">
             ✓
           </div>
           <span className="mt-1 text-sm">캡쳐완료</span>
         </div>
         <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-yellow-500">
             Ⅱ
           </div>
           <span className="mt-1 text-sm">일시중지</span>
         </div>
         <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-red-500">
             ✕
           </div>
           <span className="mt-1 text-sm">끄기</span>

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -3,3 +3,9 @@
 .btn-orange {
   @apply w-1/2 cursor-pointer rounded-2xl bg-orange-500 px-5 py-3 text-center text-lg font-bold text-white shadow hover:bg-orange-600;
 }
+.main-container {
+  @apply flex min-h-screen flex-col items-center justify-between bg-white pt-10 pb-12;
+}
+.recording-overlay {
+  @apply fixed top-0 left-0 z-[999999] flex h-screen w-screen items-center justify-center bg-black/70 text-2xl text-white;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -20,8 +20,8 @@ export default defineConfig({
           dest: "background",
         },
         {
-          src: "src/content/captureOverlay.js",
-          dest: ".",
+          src: "src/content/style/style.css",
+          dest: "style",
         },
       ],
     }),
@@ -35,6 +35,15 @@ export default defineConfig({
     rollupOptions: {
       input: {
         sidepanel: path.resolve(__dirname, "src/sidepanel/index.html"),
+        captureOverlay: path.resolve(__dirname, "src/content/captureOverlay.js"),
+      },
+      output: {
+        entryFileNames: (chunk) => {
+          if (chunk.name === "captureOverlay") {
+            return "captureOverlay.js";
+          }
+          return "assets/[name]-[hash].js";
+        },
       },
     },
     outDir: "dist",


### PR DESCRIPTION
## #️⃣ Issue Number #16 


## 📝 세부 내용

* background.js에서 chrome.tabs.captureVisibleTab을 이용하여 현재 탭 화면을 캡처하고, 그 이미지를 side panel로 전송하는 기능을 구현했습니다.
* manifest.json에 tabs 권한을 추가하여 탭 정보 접근이 가능하도록 설정했습니다.
* 캡처 시작 시, 모든 탭에 content script를 주입하여 사용자 클릭 이벤트를 감지하고 이를 background로 전달할 수 있도록 구성했습니다.
* background는 content script와 통신하며 캡처된 이미지를 실시간으로 side panel에 반영합니다.

## 💬 리뷰 요청 사항
* content script 주입 및 메시지 전달 흐름이 자연스러운지 확인 부탁드립니다.
* background → side panel 통신 구조에 개선이 필요한지 검토해 주세요.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
