### PR TITLE
feat: taskboard-title-create 기능 구현 (#14)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -39,7 +39,13 @@ const TaskBoard = () => {
                 <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
                   {index + 1}
                 </div>
-                <div className="font-bold">TEST TITLE ⋯</div>
+                <div>
+                  {elementData[index].textContent === "" ? (
+                    <div className="font-bold">"여기"를 클릭해주세요!!</div>
+                  ) : (
+                    <div className="font-bold">{`"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}</div>
+                  )}
+                </div>
               </div>
               <button className="text-lg text-red-500">⋯</button>
             </div>
@@ -48,11 +54,6 @@ const TaskBoard = () => {
                 src={image}
                 className="max-h-full max-w-full object-contain"
               />
-            </div>
-            <div>
-              <div>태그 이름: {elementData[index].tagName}</div>
-              <div>요소 텍스트: {elementData[index].textContent}</div>
-              <div>rect 정보: {JSON.stringify(elementData[index].rect)}</div>
             </div>
             {index !== images.length - 1 && (
               <div className="flex justify-center text-2xl text-gray-400">↓</div>


### PR DESCRIPTION
## #️⃣ Issue Number #14

## 📝 세부 내용
클릭한 엘리먼트 내의 innerText의 내용을 반영하여
매뉴얼 페이지의 제목을 자동으로 생성합니다.
매뉴얼을 보고 따라할 사용자에게 행동해야할 태스크의 내용을 구체화 할 수 있도록 돕는 기능입니다. 

## 💬 리뷰 요청 사항

- 클릭한 엘리먼트 내의 innerText의 내용을 반영하여 매뉴얼 페이지의 제목을 자동으로 생성하는지 확인 부탁드립니다.
- 특정 내요잉 없는 태그의 경우 '"이곳" 클릭하면 된다'고 잘 안내하는지 확인 부탁드립니다.
- 글자수가 많은 컨텐츠의 경우 내용을 줄여서 잘 안내하는지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
