### PR TITLE
feat: 캡쳐 일시중지 기능구현(#15)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -1,8 +1,18 @@
-import { useEffect, useState } from "react";
+import "@/styles/styles.css";
+
+import { useEffect, useState, useRef } from "react";
 
 const TaskBoard = () => {
   const [images, setImages] = useState([]);
   const [elementData, setElementData] = useState([]);
+  const [isCapturing, setIsCapturing] = useState(true);
+
+  const isCapturingRef = useRef(isCapturing);
+
+  const handlePauseClick = () => {
+    console.log(isCapturing);
+    isCapturing === true ? setIsCapturing(false) : setIsCapturing(true);
+  };
 
   useEffect(() => {
     chrome.runtime.sendMessage({ type: "START_CAPTURE" }, () => {
@@ -13,7 +23,7 @@ const TaskBoard = () => {
     });
 
     const handleMessage = (message) => {
-      if (message.type === "CAPTURED_IMAGE") {
+      if (message.type === "CAPTURED_IMAGE" && isCapturingRef.current) {
         setImages((prev) => [...prev, message.image]);
         setElementData((prev) => [...prev, message.elementData]);
       }
@@ -26,57 +36,113 @@ const TaskBoard = () => {
     };
   }, []);
 
+  useEffect(() => {
+    isCapturingRef.current = isCapturing;
+  }, [isCapturing]);
+
   return (
-    <div className="flex h-screen flex-col bg-white">
-      <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
-        {images.map((image, index) => (
-          <div
-            key={index}
-            className="space-y-2"
-          >
-            <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
-              <div className="flex items-center space-x-2">
-                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
-                  {index + 1}
-                </div>
-                <div>
-                  {elementData[index].textContent === "" ? (
-                    <div className="font-bold">"여기"를 클릭해주세요!!</div>
-                  ) : (
-                    <div className="font-bold">{`"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}</div>
-                  )}
-                </div>
+    <div className="flex min-h-screen w-full flex-col">
+      <div className="- flex justify-around bg-orange-500 py-4 text-white">
+        <div className="flex flex-col items-center">
+          {isCapturing === true ? (
+            <div className="flex items-center justify-center">
+              <div className="flex h-12 w-12 items-center justify-center bg-white">
+                <div className="flex h-6 w-6 animate-pulse rounded-full bg-orange-500" />
               </div>
-              <button className="text-lg text-red-500">⋯</button>
+              <div className="ml-3 flex animate-pulse text-3xl text-white">캡쳐중...</div>
             </div>
-            <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
-              <img
-                src={image}
-                className="max-h-full max-w-full object-contain"
-              />
+          ) : (
+            <div>
+              <div className="ml-3 flex text-3xl text-white">캡쳐 일시중단</div>
             </div>
-            {index !== images.length - 1 && (
-              <div className="flex justify-center text-2xl text-gray-400">↓</div>
-            )}
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 px-4 py-6">
+        {images.length === 0 ? (
+          <div className="flex h-full items-center justify-center text-xl text-gray-400">
+            캡쳐된 내용이 없습니다.
           </div>
-        ))}
+        ) : (
+          images.map((image, index) => (
+            <div
+              key={index}
+              className="space-y-2"
+            >
+              <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
+                <div className="flex items-center space-x-2">
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
+                    {index + 1}
+                  </div>
+                  <div>
+                    {elementData[index].textContent === "" ? (
+                      <div className="font-bold">"여기"를 클릭해주세요!!</div>
+                    ) : (
+                      <div className="font-bold">{`"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}</div>
+                    )}
+                  </div>
+                </div>
+                <button className="text-lg text-red-500">⋯</button>
+              </div>
+              <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
+                <img
+                  src={image}
+                  className="max-h-full max-w-full object-contain"
+                />
+              </div>
+              {index !== images.length - 1 && (
+                <div className="flex justify-center text-2xl text-gray-400">↓</div>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+
+      <div>
+        {isCapturing === true ? (
+          <div className="flex items-center justify-center">
+            <div className="ml-3 flex animate-pulse text-xl text-gray-400">캡쳐중...</div>
+          </div>
+        ) : (
+          <div className="flex items-center justify-center">
+            <div className="ml-3 flex text-xl text-gray-400">캡쳐 일시중단</div>
+          </div>
+        )}
       </div>
 
       <div className="flex justify-around bg-orange-500 py-4 text-white">
         <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-green-500">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl">
             ✓
           </div>
           <span className="mt-1 text-sm">캡쳐완료</span>
         </div>
-        <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-yellow-500">
-            Ⅱ
-          </div>
-          <span className="mt-1 text-sm">일시중지</span>
+        <div>
+          {isCapturing === true ? (
+            <div className="flex flex-col items-center">
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+                onClick={handlePauseClick}
+              >
+                ǁ
+              </div>
+              <span className="mt-1 text-sm">일시중지</span>
+            </div>
+          ) : (
+            <div className="flex flex-col items-center">
+              <div
+                className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+                onClick={handlePauseClick}
+              >
+                <div className="ml-[2px]">▶</div>
+              </div>
+              <span className="mt-1 text-sm">캡쳐 계속진행</span>
+            </div>
+          )}
         </div>
         <div className="flex flex-col items-center">
-          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-red-500">
+          <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl">
             ✕
           </div>
           <span className="mt-1 text-sm">끄기</span>

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -42,7 +42,7 @@ const TaskBoard = () => {
 
   return (
     <div className="flex min-h-screen w-full flex-col">
-      <div className="- flex justify-around bg-orange-500 py-4 text-white">
+      <div className="flex justify-around bg-orange-500 py-4 text-white">
         <div className="flex flex-col items-center">
           {isCapturing === true ? (
             <div className="flex items-center justify-center">
@@ -76,11 +76,11 @@ const TaskBoard = () => {
                     {index + 1}
                   </div>
                   <div>
-                    {elementData[index].textContent === "" ? (
-                      <div className="font-bold">"여기"를 클릭해주세요!!</div>
-                    ) : (
-                      <div className="font-bold">{`"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}</div>
-                    )}
+                    <div className="font-bold">
+                      {elementData[index].textContent === ""
+                        ? `"여기"를 클릭해주세요!!`
+                        : `"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}
+                    </div>
                   </div>
                 </div>
                 <button className="text-lg text-red-500">⋯</button>
@@ -100,15 +100,13 @@ const TaskBoard = () => {
       </div>
 
       <div>
-        {isCapturing === true ? (
-          <div className="flex items-center justify-center">
+        <div className="flex items-center justify-center">
+          {isCapturing === true ? (
             <div className="ml-3 flex animate-pulse text-xl text-gray-400">캡쳐중...</div>
-          </div>
-        ) : (
-          <div className="flex items-center justify-center">
+          ) : (
             <div className="ml-3 flex text-xl text-gray-400">캡쳐 일시중단</div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
 
       <div className="flex justify-around bg-orange-500 py-4 text-white">
@@ -119,27 +117,15 @@ const TaskBoard = () => {
           <span className="mt-1 text-sm">캡쳐완료</span>
         </div>
         <div>
-          {isCapturing === true ? (
-            <div className="flex flex-col items-center">
-              <div
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-                onClick={handlePauseClick}
-              >
-                ǁ
-              </div>
-              <span className="mt-1 text-sm">일시중지</span>
+          <div className="flex flex-col items-center">
+            <div
+              className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+              onClick={handlePauseClick}
+            >
+              {isCapturing ? "ǁ" : <div className="ml-[2px]">▶</div>}
             </div>
-          ) : (
-            <div className="flex flex-col items-center">
-              <div
-                className="flex h-12 w-12 items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-                onClick={handlePauseClick}
-              >
-                <div className="ml-[2px]">▶</div>
-              </div>
-              <span className="mt-1 text-sm">캡쳐 계속진행</span>
-            </div>
-          )}
+            <span className="mt-1 text-sm">{isCapturing ? "일시중지" : "캡쳐 계속진행"}</span>
+          </div>
         </div>
         <div className="flex flex-col items-center">
           <div className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl">


### PR DESCRIPTION
## #️⃣ Issue Number #15

## 📝 세부 내용

- 일시중지 버튼을 누르면 브라우저에서 이동을 하고 누르는 태그는 표시되더라도 매뉴얼 생성자체는 중단하는 기능 구현하였습니다.
   사용자가 다른 페이지로 이동하거나  원치 않는 표시가 저장되지 않도록 하는 기능입니다.
- 사용자가 직관적으로 캡쳐중인지, 캡쳐 일시정지 중인지 알 수있도록 토글 버튼으로 현 상태를 표시를 하였습니다.
- 하단 버튼 이동시 호버기능을 이용하여 자신이 현재 어떤 버튼을 누를 수 있는지 알 수 있도록 했습니다.

## 📸 스크린샷(선택)
<img src="https://github.com/user-attachments/assets/c1fb0af9-047d-4e62-9155-a62fcc03f15b" width="300" />

<img src="https://github.com/user-attachments/assets/0f7b46fe-47d5-452a-bacd-f6ab53f93df1" width="300" />

## 💬 리뷰 요청 사항

- 매뉴얼 캡쳐 중단, 다시 캡쳐 진행이 원활하게 되는지 확인 부탁드립니다.
- 사용자가 편안하게 현재 상태를 확인 할 수 있는지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
