### PR TITLE
feat: TaskCard 컴포넌트 분리 및 제목 더블 클릭 시 수정 기능 구현 (#24)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -1,0 +1,50 @@
+import { useState } from "react";
+
+const TaskCard = ({ element, onTitleChange }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [inputValue, setInputValue] = useState(element.textContent);
+
+  const handleDoubleClick = () => {
+    setIsEditing(true);
+  };
+
+  const handleChange = (e) => {
+    setInputValue(e.target.value);
+  };
+
+  const finishEditing = () => {
+    setIsEditing(false);
+    if (onTitleChange) {
+      onTitleChange(inputValue);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === "Enter") {
+      finishEditing();
+    }
+  };
+
+  return (
+    <div onDoubleClick={handleDoubleClick}>
+      {isEditing ? (
+        <input
+          value={inputValue}
+          onChange={handleChange}
+          onBlur={finishEditing}
+          onKeyDown={handleKeyDown}
+          autoFocus
+          className="rounded border px-1 font-bold"
+        />
+      ) : (
+        <div className="font-bold">
+          {element.textContent === ""
+            ? `"여기"를 클릭해주세요!!`
+            : `${element.textContent.trim().substring(0, 13)}`}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default TaskCard;

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 
+import TaskCard from "./TaskCard";
+
 const TaskBoard = () => {
   const [images, setImages] = useState([]);
   const [elementData, setElementData] = useState([]);
@@ -39,13 +41,14 @@ const TaskBoard = () => {
                 <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
                   {index + 1}
                 </div>
-                <div>
-                  {elementData[index].textContent === "" ? (
-                    <div className="font-bold">"여기"를 클릭해주세요!!</div>
-                  ) : (
-                    <div className="font-bold">{`"${elementData[index].textContent.trim().substring(0, 13)}"을 클릭해주세요!!`}</div>
-                  )}
-                </div>
+                <TaskCard
+                  element={elementData[index]}
+                  onTitleChange={(newTitle) => {
+                    const updated = [...elementData];
+                    updated[index].textContent = newTitle;
+                    setElementData(updated);
+                  }}
+                />
               </div>
               <button className="text-lg text-red-500">⋯</button>
             </div>


### PR DESCRIPTION
## #️⃣ Issue Number #24 

## 📝 세부 내용

- TaskCard 컴포넌트를 별도 파일로 분리하여 구조화
- 카드 제목을 더블 클릭 시 인라인 수정 가능한 기능 구현
- 수정 후 Enter 키 입력 또는 포커스 아웃 시 저장되도록 처리

## 💬 리뷰 요청 사항

제목 수정 인터랙션 흐름이 자연스러운지 확인 부탁드립니다
컴포넌트 분리 구조에 개선점이 있을지 피드백 요청드립니다

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
