### PR TITLE
refactor: TaskCard 컴포넌트로 분리 및 TaskBoard 리팩터링 (#28)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const TaskCard = ({ index, element, image, onTitleChange, onDelete }) => {
+const TaskCard = ({ index, element, image, onTitleChange }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(element.textContent);
 
@@ -41,12 +41,6 @@ const TaskCard = ({ index, element, image, onTitleChange, onDelete }) => {
             </div>
           )}
         </div>
-        <button
-          onClick={onDelete}
-          className="text-lg text-red-500 hover:text-red-700"
-        >
-          ⋯
-        </button>
       </div>
 
       <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">

--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -1,48 +1,60 @@
 import { useState } from "react";
 
-const TaskCard = ({ element, onTitleChange }) => {
+const TaskCard = ({ index, element, image, onTitleChange, onDelete }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(element.textContent);
 
-  const handleDoubleClick = () => {
-    setIsEditing(true);
-  };
-
-  const handleChange = (e) => {
-    setInputValue(e.target.value);
-  };
+  const handleDoubleClick = () => setIsEditing(true);
+  const handleChange = (e) => setInputValue(e.target.value);
 
   const finishEditing = () => {
     setIsEditing(false);
-    if (onTitleChange) {
-      onTitleChange(inputValue);
-    }
+    onTitleChange?.(inputValue);
   };
 
   const handleKeyDown = (e) => {
-    if (e.key === "Enter") {
-      finishEditing();
-    }
+    if (e.key === "Enter") finishEditing();
   };
 
   return (
-    <div onDoubleClick={handleDoubleClick}>
-      {isEditing ? (
-        <input
-          value={inputValue}
-          onChange={handleChange}
-          onBlur={finishEditing}
-          onKeyDown={handleKeyDown}
-          autoFocus
-          className="rounded border px-1 font-bold"
-        />
-      ) : (
-        <div className="font-bold">
-          {element.textContent === ""
-            ? `"여기"를 클릭해주세요!!`
-            : `${element.textContent.trim().substring(0, 13)}`}
+    <div className="space-y-2">
+      <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
+        <div className="flex items-center space-x-2">
+          <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
+            {index + 1}
+          </div>
+          {isEditing ? (
+            <input
+              value={inputValue}
+              onChange={handleChange}
+              onBlur={finishEditing}
+              onKeyDown={handleKeyDown}
+              autoFocus
+              className="rounded border px-1 font-bold"
+            />
+          ) : (
+            <div
+              className="cursor-pointer font-bold"
+              onDoubleClick={handleDoubleClick}
+            >
+              {inputValue?.trim().substring(0, 13) || '"여기"를 클릭해주세요!!'}
+            </div>
+          )}
         </div>
-      )}
+        <button
+          onClick={onDelete}
+          className="text-lg text-red-500 hover:text-red-700"
+        >
+          ⋯
+        </button>
+      </div>
+
+      <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
+        <img
+          src={image}
+          className="max-h-full max-w-full object-contain"
+        />
+      </div>
     </div>
   );
 };

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -42,12 +42,6 @@ const TaskBoard = () => {
               updated[index].textContent = newTitle;
               setElementData(updated);
             }}
-            onDelete={() => {
-              const updatedImages = images.filter((_, i) => i !== index);
-              const updatedElements = elementData.filter((_, i) => i !== index);
-              setImages(updatedImages);
-              setElementData(updatedElements);
-            }}
           />
         ))}
       </div>

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -32,36 +32,23 @@ const TaskBoard = () => {
     <div className="flex h-screen flex-col bg-white">
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {images.map((image, index) => (
-          <div
+          <TaskCard
             key={index}
-            className="space-y-2"
-          >
-            <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
-              <div className="flex items-center space-x-2">
-                <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
-                  {index + 1}
-                </div>
-                <TaskCard
-                  element={elementData[index]}
-                  onTitleChange={(newTitle) => {
-                    const updated = [...elementData];
-                    updated[index].textContent = newTitle;
-                    setElementData(updated);
-                  }}
-                />
-              </div>
-              <button className="text-lg text-red-500">⋯</button>
-            </div>
-            <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
-              <img
-                src={image}
-                className="max-h-full max-w-full object-contain"
-              />
-            </div>
-            {index !== images.length - 1 && (
-              <div className="flex justify-center text-2xl text-gray-400">↓</div>
-            )}
-          </div>
+            index={index}
+            element={elementData[index]}
+            image={image}
+            onTitleChange={(newTitle) => {
+              const updated = [...elementData];
+              updated[index].textContent = newTitle;
+              setElementData(updated);
+            }}
+            onDelete={() => {
+              const updatedImages = images.filter((_, i) => i !== index);
+              const updatedElements = elementData.filter((_, i) => i !== index);
+              setImages(updatedImages);
+              setElementData(updatedElements);
+            }}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## #️⃣ Issue Number #28 



## 📝 세부 내용

어제 대환님 피드백 기반으로 taskcard 분리를 이름에 맞게 수정 했습니다.
TaskBoard 내 태스크 렌더링 UI를 별도 TaskCard 컴포넌트로 분리했습니다.
컴포넌트가 index, element, image, onTitleChange를 props로 받아 재사용성과 유지보수성을 개선했습니다.
제목 수정 기능만 포함되어 있습니다.


## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
