### PR TITLE
fix: 제목 및 캡쳐된 이미지 같은줄에 표시되는 UI 버그 수정 (#33)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -40,7 +40,7 @@ const TaskCard = ({ element, onTitleChange }) => {
         <div className="font-bold">
           {element.textContent === ""
             ? `"여기"를 클릭해주세요!!`
-            : `${element.textContent.trim().substring(0, 13)}`}
+            : `"${element.textContent.trim().substring(0, 13)}"를 클릭해주세요`}
         </div>
       )}
     </div>

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -68,41 +68,38 @@ const TaskBoard = () => {
           </div>
         ) : (
           images.map((image, index) => (
-            <div>
-              <div
-                key={index}
-                className="space-y-2"
-              >
-                <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
-                  <div className="flex items-center space-x-2">
-                    <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
-                      {index + 1}
-                    </div>
-
-                    <TaskCard
-                      element={elementData[index]}
-                      onTitleChange={(newTitle) => {
-                        const updated = [...elementData];
-                        updated[index].textContent = newTitle;
-                        setElementData(updated);
-                      }}
-                    />
-
-                    <div
-                      key={index}
-                      className="space-y-2"
-                    >
-                      <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
-                        <img
-                          src={image}
-                          alt=""
-                          className="max-h-full max-w-full object-contain"
-                        />
-                      </div>
-                    </div>
+            <div
+              key={index}
+              className="space-y-2"
+            >
+              <div className="flex items-center justify-between rounded-md bg-gray-200 px-3 py-2">
+                <div className="flex items-center space-x-2">
+                  <div className="flex h-5 w-5 items-center justify-center rounded-full bg-orange-500 text-xs font-bold text-white">
+                    {index + 1}
                   </div>
+
+                  <TaskCard
+                    element={elementData[index]}
+                    onTitleChange={(newTitle) => {
+                      const updated = [...elementData];
+                      updated[index].textContent = newTitle;
+                      setElementData(updated);
+                    }}
+                  />
                 </div>
               </div>
+
+              <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">
+                <img
+                  src={image}
+                  alt=""
+                  className="max-h-full max-w-full object-contain"
+                />
+              </div>
+
+              {index !== images.length - 1 && (
+                <div className="flex justify-center text-2xl text-gray-400">↓</div>
+              )}
             </div>
           ))
         )}


### PR DESCRIPTION
## #️⃣ Issue Number #33 


## 📝 세부 내용

- 이미지와 TaskCard 제목이 같은 줄에 렌더링되어 UI가 깨지는 문제를 수정했습니다.
- TaskCard와 이미지(img)가 같은 flex row 안에 있어 옆으로 나란히 붙는 현상이 있었으며, 이를 이미지가 아래로 렌더링되도록 구조를 수정하여 해결했습니다.
- UI는 기존과 동일하게 유지되며, 캡처된 이미지와 제목이 각기 독립된 줄에 표시됩니다.


## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
