### PR TITLE
feat: 태스크 보드 항목 삭제 기능 구현 (#25)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react-dom": "^19.1.0",
         "react-router-dom": "^7.6.2",
         "swiper": "^11.2.8",
-        "tailwindcss": "^4.1.8"
+        "tailwindcss": "^4.1.8",
+        "uuid": "^11.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.28.0",
@@ -6292,6 +6293,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2",
     "swiper": "^11.2.8",
-    "tailwindcss": "^4.1.8"
+    "tailwindcss": "^4.1.8",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.28.0",

--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-const TaskCard = ({ index, element, image, onTitleChange }) => {
+const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(element?.textContent || "");
 
@@ -43,6 +43,12 @@ const TaskCard = ({ index, element, image, onTitleChange }) => {
             </div>
           )}
         </div>
+        <button
+          className="cursor-pointer transition-all duration-200 hover:text-2xl"
+          onClick={onDeleteStep}
+        >
+          🗑️
+        </button>
       </div>
 
       <div className="flex h-32 items-center justify-center rounded-md bg-gray-300 text-gray-600">

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -1,11 +1,11 @@
 import "@/styles/styles.css";
 import { useEffect, useState, useRef } from "react";
+import { v4 as uuidv4 } from "uuid";
 
 import TaskCard from "./TaskCard";
 
 const TaskBoard = () => {
-  const [images, setImages] = useState([]);
-  const [elementData, setElementData] = useState([]);
+  const [steps, setSteps] = useState([]);
   const [isCapturing, setIsCapturing] = useState(true);
 
   const isCapturingRef = useRef(isCapturing);
@@ -24,8 +24,14 @@ const TaskBoard = () => {
 
     const handleMessage = (message) => {
       if (message.type === "CAPTURED_IMAGE" && isCapturingRef.current) {
-        setImages((prev) => [...prev, message.image]);
-        setElementData((prev) => [...prev, message.elementData]);
+        setSteps((prev) => [
+          ...prev,
+          {
+            id: uuidv4(),
+            image: message.image,
+            elementData: message.elementData,
+          },
+        ]);
       }
     };
 
@@ -39,8 +45,8 @@ const TaskBoard = () => {
     isCapturingRef.current = isCapturing;
   }, [isCapturing]);
 
-  const handleDeleteStep = (index) => {
-    console.log("DELETED INDEX: " + index);
+  const handleDeleteStep = (taskId) => {
+    setSteps((prev) => prev.filter((step) => step.id !== taskId));
   };
 
   return (
@@ -61,28 +67,27 @@ const TaskBoard = () => {
       </div>
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
-        {images.length === 0 ? (
+        {steps.length === 0 ? (
           <div className="flex h-full items-center justify-center text-xl text-gray-400">
             캡쳐된 내용이 없습니다.
           </div>
         ) : (
-          images.map((image, index) => (
+          steps.map((step, index) => (
             <div
-              key={index}
+              key={step.id}
               className="space-y-2"
             >
               <TaskCard
                 index={index}
-                element={elementData[index]}
-                image={image}
-                onDeleteStep={() => handleDeleteStep(index)}
+                element={step.elementData}
+                image={step.image}
+                onDeleteStep={() => handleDeleteStep(step.id)}
                 onTitleChange={(newTitle) => {
-                  const updated = [...elementData];
+                  const updated = [...step.elementData];
                   updated[index].textContent = newTitle;
-                  setElementData(updated);
                 }}
               />
-              {index !== images.length - 1 && (
+              {index !== steps.length - 1 && (
                 <div className="flex justify-center text-2xl text-gray-400">↓</div>
               )}
             </div>

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -39,6 +39,10 @@ const TaskBoard = () => {
     isCapturingRef.current = isCapturing;
   }, [isCapturing]);
 
+  const handleDeleteStep = (index) => {
+    console.log("DELETED INDEX: " + index);
+  };
+
   return (
     <div className="flex min-h-screen w-full flex-col bg-white">
       <div className="flex justify-around bg-orange-500 py-4 text-white">
@@ -71,6 +75,7 @@ const TaskBoard = () => {
                 index={index}
                 element={elementData[index]}
                 image={image}
+                onDeleteStep={() => handleDeleteStep(index)}
                 onTitleChange={(newTitle) => {
                   const updated = [...elementData];
                   updated[index].textContent = newTitle;


### PR DESCRIPTION
## #️⃣ Issue Number #25 


## 📝 세부 내용

- 사이드 패널에서 Task 삭제 버튼 클릭 시, 실시간으로 Task가 삭제되도록 구현했습니다.
- 삭제 기능을 구현하는 과정에서, 캡처된 이미지를 `.map()`으로 렌더링할 때 key로 index를 사용해 문제가 발생했습니다. 이를 해결하기 위해 `uuid` 라이브러리를 설치하고, 각 `TaskCard` 컴포넌트에 고유한 `id`를 `key`로 사용하도록 수정했습니다.
- 기존에는 캡처된 이미지와 클릭된 요소 정보를 별도의 상태값으로 관리했지만, 삭제 기능을 구현하면서 유지보수에 비효율적이라는 점을 발견하고, 하나의 배열 state로 통합하여 구조를 개선했습니다.

### package.json에 uuid가 추가되어 이번에 pull 하신 후에는 반드시 npm install을 실행해 주세요.


## 💬 리뷰 요청 사항

- Task 삭제 및 key 관리 구조 개선에 대해 피드백 부탁드립니다.
- 삭제 기능 구현하면서 통합해야 유지보수성이 좋다고 판단해서 통합했지만 혹시 통합한 상태 관리 방식이 적절한지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
