### PR TITLE
feat: option-colorPicker (#35)

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "version": "1.0",
   "manifest_version": 3,
 
-  "permissions": ["sidePanel","scripting", "activeTab"],
+  "permissions": ["sidePanel","scripting", "activeTab", "storage"],
 
   "host_permissions": ["<all_urls>"],
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -23,6 +23,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === "SEND_COLOR") {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      chrome.tabs.sendMessage(tabs[0].id, {
+        type: "SEND_COLOR",
+        data: message.data,
+      });
+    });
+  }
+
   if (message.type === "CLICKED") {
     chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
       chrome.runtime.sendMessage({
@@ -33,6 +42,7 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
       sendResponse({ status: "captured" });
     });
+
     return true;
   }
 });

--- a/src/content/script/clickListener.js
+++ b/src/content/script/clickListener.js
@@ -1,6 +1,20 @@
 let currentOverlay = null;
 let targetElementInfo = null;
 
+let selectedColor = "#bf0000";
+
+chrome.storage.local.get("selectedColor", (result) => {
+  if (result.selectedColor) {
+    selectedColor = result.selectedColor;
+  }
+});
+
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "SEND_COLOR") {
+    selectedColor = message.data;
+  }
+});
+
 window.addEventListener("mousedown", (event) => {
   const target = event.target;
   const rect = target.getBoundingClientRect();
@@ -14,7 +28,8 @@ window.addEventListener("mousedown", (event) => {
   overlay.style.left = `${window.scrollX + rect.left - 6}px`;
   overlay.style.width = `${rect.width + 12}px`;
   overlay.style.height = `${rect.height + 12}px`;
-  overlay.style.border = "5px solid rgb(174, 191, 0)";
+  overlay.style.border =
+    selectedColor === undefined ? "5px solid #bf0000" : `5px solid ${selectedColor}`;
   overlay.style.zIndex = "999999";
   overlay.style.pointerEvents = "none";
   document.body.appendChild(overlay);

--- a/src/sidepanel/pages/Settings/Option/index.jsx
+++ b/src/sidepanel/pages/Settings/Option/index.jsx
@@ -1,7 +1,32 @@
 import "@/styles/styles.css";
+import { useState, useEffect } from "react";
+
 import BackButton from "@/sidepanel/components/BackButton";
 
 const Option = () => {
+  const [squareColor, setSquareColor] = useState("#ff0000");
+
+  const handleChange = (e) => {
+    const selected = e.target.value;
+    setSquareColor(selected);
+    chrome.storage.local.set({ selectedColor: selected });
+  };
+
+  useEffect(() => {
+    chrome.storage.local.get("selectedColor", (result) => {
+      if (result.selectedColor) {
+        setSquareColor(result.selectedColor);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    chrome.runtime.sendMessage({
+      type: "SEND_COLOR",
+      data: squareColor,
+    });
+  }, [squareColor]);
+
   return (
     <div className="flex min-h-screen flex-col bg-white px-4 pt-10 pb-12">
       <BackButton />
@@ -12,11 +37,12 @@ const Option = () => {
 
       <div className="mt-24 flex flex-col items-center">
         <p className="mb-2 text-3xl font-bold text-stone-900">강조표시 색상</p>
-
         <input
+          id="colorInput"
           type="color"
+          onChange={handleChange}
           className="h-32 w-32 cursor-pointer rounded border border-black"
-          defaultValue="#ff0000"
+          defaultValue={squareColor}
         />
       </div>
     </div>


### PR DESCRIPTION
## #️⃣ Issue Number #35

## 📝 세부 내용

옵션에서 색상을 선택하면 그 색상이 강조표시 사각형의 색상에 반영되도록 하는 기능입니다.
chrome.storage와 chrome.runtime.onMessage 둘 중 하나를 단독으로만 사용하면 기능 구현에 예외가 발생하고,
2중으로 사용하는 경우 한쪽이 선택된 색상 값을 전하는데 오히려 더 확실한 측면이 있어
두 기능을 2중으로 사용하여 색상값을 유지하도록 하였습니다.

## 💬 리뷰 요청 사항

옵션 기능 들어가서 생상 선택이 잘 구현되는지 확인 부탁드립니다.
색상 선택 즉시 화면에 강조표시 색상이 잘 변경되는지 확인 부탁드립니다.
색상을 선택하면 그 색상이 잘 유지되는지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
