### PR TITLE
feat: 삭제 버튼 클릭 시 DeleteConfirmModal을 통해 삭제 여부 확인 기능 구현

### DIFF
--- a/src/sidepanel/components/DeleteConfirmModal.jsx
+++ b/src/sidepanel/components/DeleteConfirmModal.jsx
@@ -24,7 +24,7 @@ const DeleteConfirmModal = ({ title, message, onCancel, onConfirm }) => {
           </button>
           <button
             onClick={onConfirm}
-            className="cursor-pointer rounded-md bg-red-600 px-4 py-2 text-sm text-white hover:bg-red-500"
+            className="cursor-pointer rounded-md bg-orange-600 px-4 py-2 text-sm text-white hover:bg-orange-500"
           >
             확인
           </button>

--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -1,8 +1,11 @@
 import { useState } from "react";
 
+import DeleteConfirmModal from "@/sidepanel/components/DeleteConfirmModal";
+
 const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [inputValue, setInputValue] = useState(element?.textContent || "");
+  const [showModal, setShowModal] = useState(false);
 
   const handleDoubleClick = () => setIsEditing(true);
   const handleChange = (e) => setInputValue(e.target.value);
@@ -14,6 +17,17 @@ const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
 
   const handleKeyDown = (e) => {
     if (e.key === "Enter") finishEditing();
+  };
+
+  const handleDeleteClick = () => {
+    setShowModal(true);
+  };
+  const handleCancelDelete = () => {
+    setShowModal(false);
+  };
+  const handleConfirmDelete = () => {
+    setShowModal(false);
+    onDeleteStep();
   };
 
   return (
@@ -45,7 +59,7 @@ const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
         </div>
         <button
           className="cursor-pointer transition-all duration-200 hover:text-2xl"
-          onClick={onDeleteStep}
+          onClick={handleDeleteClick}
         >
           🗑️
         </button>
@@ -58,6 +72,14 @@ const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
           className="max-h-full max-w-full object-contain"
         />
       </div>
+      {showModal && (
+        <DeleteConfirmModal
+          title="캡처 이미지 삭제"
+          message="해당 단계를 삭제하시겠습니까?"
+          onCancel={handleCancelDelete}
+          onConfirm={handleConfirmDelete}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number #41 


## 📝 세부 내용

- TaskCard 컴포넌트에 삭제 아이콘 클릭 시 `확인 모달(DeleteConfirmModal)`이 나타나도록 기능을 추가했습니다.
- 실수로 단계를 삭제하지 않도록 방지하고자 모달에서 확인 후 삭제되도록 처리했습니다.
- DeleteConfirmModal 컴포넌트를 재사용 가능하게 구현하여 향후 다른 삭제 기능에도 활용할 수 있습니다.


## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
