### PR TITLE
fix: 사이드패널 재진입 시 캡처 내용 복원 처리 (#55)

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -13,6 +13,15 @@ chrome.runtime.onInstalled.addListener(() => {
   });
 });
 
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (changeInfo.status === "complete" && tab.url && /^https?:/.test(tab.url)) {
+    chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["content/clickListener.js"],
+    });
+  }
+});
+
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === "START_CAPTURE") {
     chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -25,6 +25,7 @@ chrome.runtime.onMessage.addListener((message) => {
         });
     });
 
+    chrome.storage.local.set({ isCapturing: true });
     return true;
   }
 });

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -44,6 +44,9 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         if (!tab.id) return;
 
         chrome.tabs.sendMessage(tab.id, { type: "STOP_CAPTURE" }, () => {
+          if (chrome.runtime.lastError) {
+            console.log("IGNORE ERROR from background.js - STOP_CAPTURE");
+          }
           completed++;
 
           if (completed === tabs.length) {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -32,13 +32,28 @@ chrome.runtime.onMessage.addListener((message) => {
 
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === "CLEANUP_ALL") {
-    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-      if (!tabs[0]?.id) return;
-      chrome.tabs.sendMessage(tabs[0].id, {
-        type: "STOP_CAPTURE",
+    chrome.tabs.query({}, (tabs) => {
+      if (!tabs || tabs.length === 0) {
+        sendResponse({ success: false });
+        return;
+      }
+
+      let completed = 0;
+
+      tabs.forEach((tab) => {
+        if (!tab.id) return;
+
+        chrome.tabs.sendMessage(tab.id, { type: "STOP_CAPTURE" }, () => {
+          completed++;
+
+          if (completed === tabs.length) {
+            sendResponse({ success: true });
+          }
+        });
       });
     });
-    return;
+
+    return true;
   }
 
   if (message.type === "SEND_COLOR") {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,5 +1,16 @@
 chrome.runtime.onInstalled.addListener(() => {
   chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+
+  chrome.tabs.query({}, (tabs) => {
+    for (const tab of tabs) {
+      if (tab.id && /^https?:/.test(tab.url)) {
+        chrome.scripting.executeScript({
+          target: { tabId: tab.id },
+          files: ["content/clickListener.js"],
+        });
+      }
+    }
+  });
 });
 
 chrome.runtime.onMessage.addListener((message) => {

--- a/src/content/script/clickListener.js
+++ b/src/content/script/clickListener.js
@@ -2,49 +2,47 @@ let currentOverlay = null;
 let targetElementInfo = null;
 
 let selectedColor = "#bf0000";
+let isCapturing = true;
 
-chrome.storage.local.get("isCaptureStopped", (result) => {
-  const stopped = result.isCaptureStopped;
-
-  if (!stopped) {
-    window.addEventListener("mousedown", handleClick);
+chrome.storage.local.get("isCapturing", (result) => {
+  if (result.isCapturing !== undefined) {
+    isCapturing = result.isCapturing;
   }
 });
 
-chrome.storage.local.get("selectedColor", (result) => {
-  if (result.selectedColor) {
-    selectedColor = result.selectedColor;
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "local" && changes.isCapturing) {
+    isCapturing = changes.isCapturing.newValue;
   }
 });
+
+if (isCapturing) {
+  window.addEventListener("mousedown", handleClick);
+} else {
+  window.removeEventListener("mousedown", handleClick);
+}
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === "SEND_COLOR") {
     selectedColor = message.data;
-  }
-});
-
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === "STOP_CAPTURE") {
-    chrome.storage.local.set({ isCaptureStopped: true });
+  } else if (message.type === "STOP_CAPTURE") {
+    chrome.storage.local.set({ isCapturing: false });
     window.removeEventListener("mousedown", handleClick);
 
     if (currentOverlay) {
       currentOverlay.remove();
       currentOverlay = null;
     }
-
     targetElementInfo = null;
-  }
-});
-
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.type === "START_CAPTURE") {
-    chrome.storage.local.set({ isCaptureStopped: false });
+  } else if (message.type === "START_CAPTURE") {
+    chrome.storage.local.set({ isCapturing: true });
     window.addEventListener("mousedown", handleClick);
   }
 });
 
 function handleClick(event) {
+  if (!isCapturing) return;
+
   const target = event.target;
   const rect = target.getBoundingClientRect();
 

--- a/src/content/script/clickListener.js
+++ b/src/content/script/clickListener.js
@@ -2,25 +2,29 @@ let currentOverlay = null;
 let targetElementInfo = null;
 
 let selectedColor = "#bf0000";
-let isCapturing = true;
+let isCapturing = false;
 
 chrome.storage.local.get("isCapturing", (result) => {
   if (result.isCapturing !== undefined) {
     isCapturing = result.isCapturing;
+
+    if (isCapturing) {
+      window.addEventListener("mousedown", handleClick);
+    }
   }
 });
 
 chrome.storage.onChanged.addListener((changes, area) => {
   if (area === "local" && changes.isCapturing) {
     isCapturing = changes.isCapturing.newValue;
+
+    if (isCapturing) {
+      window.addEventListener("mousedown", handleClick);
+    } else {
+      window.removeEventListener("mousedown", handleClick);
+    }
   }
 });
-
-if (isCapturing) {
-  window.addEventListener("mousedown", handleClick);
-} else {
-  window.removeEventListener("mousedown", handleClick);
-}
 
 chrome.runtime.onMessage.addListener((message) => {
   if (message.type === "SEND_COLOR") {

--- a/src/sidepanel/App.jsx
+++ b/src/sidepanel/App.jsx
@@ -40,8 +40,6 @@ const App = () => {
     }
   }, [isLoggedIn]);
 
-  
-
   useEffect(() => {
     getCaptureStatus().then((result) => {
       setIsCapturing(result);

--- a/src/sidepanel/App.jsx
+++ b/src/sidepanel/App.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useNavigate, Routes, Route } from "react-router-dom";
+import { useNavigate, Routes, Route, Navigate, useLocation } from "react-router-dom";
 
 import Login from "@/sidepanel/pages/Login";
 import MainPage from "@/sidepanel/pages/MainPage";
@@ -10,10 +10,14 @@ import DeleteAccount from "@/sidepanel/pages/Settings/DeleteAccount";
 import NoticeDeleteAccount from "@/sidepanel/pages/Settings/DeleteAccount/NoticeDeleteAccount";
 import Option from "@/sidepanel/pages/Settings/Option";
 import TaskBoard from "@/sidepanel/pages/Taskboard";
+import { getCaptureStatus } from "@/utils/storage.js";
 
 const App = () => {
-  const [isLoggedIn, setIsLoggedIn] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
+
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [isCapturing, setIsCapturing] = useState(null);
 
   useEffect(() => {
     const token = localStorage.getItem("accessToken");
@@ -35,6 +39,26 @@ const App = () => {
       navigate("/login");
     }
   }, [isLoggedIn]);
+
+  
+
+  useEffect(() => {
+    getCaptureStatus().then((result) => {
+      console.log(result);
+      setIsCapturing(result);
+    });
+  }, []);
+
+  if (isCapturing === null) return null;
+
+  if (isCapturing && location.pathname !== "/taskboard") {
+    return (
+      <Navigate
+        to="/taskboard"
+        replace
+      />
+    );
+  }
 
   return (
     <Routes>

--- a/src/sidepanel/App.jsx
+++ b/src/sidepanel/App.jsx
@@ -44,9 +44,19 @@ const App = () => {
 
   useEffect(() => {
     getCaptureStatus().then((result) => {
-      console.log(result);
       setIsCapturing(result);
     });
+  }, []);
+
+  useEffect(() => {
+    const listener = (changes, area) => {
+      if (area === "local" && changes.isCapturing) {
+        setIsCapturing(changes.isCapturing.newValue);
+      }
+    };
+
+    chrome.storage.onChanged.addListener(listener);
+    return () => chrome.storage.onChanged.removeListener(listener);
   }, []);
 
   if (isCapturing === null) return null;

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -6,6 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import createManual from "@/api/createManual";
 import LoadingModal from "@/sidepanel/components/LoadingModal";
 import WarningModal from "@/sidepanel/components/WarningModal";
+import { setCaptureStatus } from "@/utils/storage";
 
 import TaskCard from "./TaskCard";
 
@@ -24,12 +25,17 @@ const TaskBoard = () => {
   };
 
   const handleCleanupClick = () => {
-    chrome.runtime.sendMessage({ type: "CLEANUP_ALL" }, () => {
-      if (chrome.runtime.lastError) {
-        console.error("CLEANUP_ALL 전송 오류:", chrome.runtime.lastError.message);
-      } else {
-        console.log("📨 CLEANUP_ALL 메시지 전송됨");
-      }
+    return new Promise((resolve) => {
+      chrome.runtime.sendMessage({ type: "CLEANUP_ALL" }, () => {
+        if (chrome.runtime.lastError) {
+          console.error("CLEANUP_ALL 전송 오류:", chrome.runtime.lastError.message);
+          resolve(false);
+        } else {
+          console.log("📨 CLEANUP_ALL 메시지 전송됨");
+          setCaptureStatus(false);
+          resolve(true);
+        }
+      });
     });
   };
 
@@ -171,9 +177,9 @@ const TaskBoard = () => {
         <div className="flex flex-col items-center">
           <button
             className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-            onClick={() => {
+            onClick={async () => {
+              await handleCleanupClick();
               goBack();
-              handleCleanupClick();
             }}
           >
             ✕

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -6,7 +6,7 @@ import { v4 as uuidv4 } from "uuid";
 import createManual from "@/api/createManual";
 import LoadingModal from "@/sidepanel/components/LoadingModal";
 import WarningModal from "@/sidepanel/components/WarningModal";
-import { setCaptureStatus } from "@/utils/storage";
+import { getCaptureStatus } from "@/utils/storage";
 
 import TaskCard from "./TaskCard";
 
@@ -21,21 +21,22 @@ const TaskBoard = () => {
   const isCapturingRef = useRef(isCapturing);
 
   const goBack = () => {
-    navigate(-1);
+    navigate("/");
   };
 
-  const handleCleanupClick = () => {
-    return new Promise((resolve) => {
-      chrome.runtime.sendMessage({ type: "CLEANUP_ALL" }, () => {
-        if (chrome.runtime.lastError) {
-          console.error("CLEANUP_ALL 전송 오류:", chrome.runtime.lastError.message);
-          resolve(false);
-        } else {
-          console.log("📨 CLEANUP_ALL 메시지 전송됨");
-          setCaptureStatus(false);
-          resolve(true);
-        }
-      });
+  const handleCleanupClick = async () => {
+    chrome.runtime.sendMessage({ type: "CLEANUP_ALL" }, async () => {
+      if (chrome.runtime.lastError) {
+        console.error("CLEANUP_ALL 전송 오류:", chrome.runtime.lastError.message);
+      } else {
+        console.log("📨 CLEANUP_ALL 메시지 전송됨");
+        await chrome.storage.local.set({ isCapturing: false });
+
+        const status = await getCaptureStatus();
+        setIsCapturing(status);
+
+        goBack();
+      }
     });
   };
 
@@ -177,10 +178,7 @@ const TaskBoard = () => {
         <div className="flex flex-col items-center">
           <button
             className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-            onClick={async () => {
-              await handleCleanupClick();
-              goBack();
-            }}
+            onClick={handleCleanupClick}
           >
             ✕
           </button>

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -76,7 +76,10 @@ const TaskBoard = () => {
   };
 
   const handlePauseClick = () => {
-    setIsCapturing((prev) => !prev);
+    setIsCapturing((prev) => {
+      chrome.storage.local.set({ isCapturing: !prev });
+      return !prev;
+    });
   };
 
   const handleFinishClick = async () => {

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -9,3 +9,12 @@ export const getCaptureStatus = () => {
     });
   });
 };
+
+export function resetCapturedSteps(callback) {
+  chrome.storage.local.set({ CapturedSteps: [] }, () => {
+    if (chrome.runtime.lastError) {
+      console.error("CapturedSteps 리셋 실패", chrome.runtime.lastError);
+    }
+    if (callback) callback();
+  });
+}

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -1,0 +1,11 @@
+export const setCaptureStatus = (value) => {
+  chrome.storage.local.set({ isCapturing: value });
+};
+
+export const getCaptureStatus = () => {
+  return new Promise((resolve) => {
+    chrome.storage.local.get("isCapturing", (result) => {
+      resolve(result.isCapturing || false);
+    });
+  });
+};


### PR DESCRIPTION
## #️⃣ Issue Number #55 

## 📝 세부 내용

 - chrome.storage.local을 활용하여 사이드패널에서 캡처 상태 및 캡처된 데이터가 유지되도록 구현했습니다.
 - 캡처 중 상태(isCapturing)가 사이드패널을 닫았다가 다시 열어도 유지되도록 자동 라우팅 및 상태 관리 개선을 진행했습니다.
 - 설치 직후 활성 탭에 클릭 리스너 스크립트를 주입하도록 수정하여 초기 이벤트 누락 문제를 해결했습니다.
 - 캡처 일시중지 시 불필요한 클릭 도형이 그려지는 문제를 수정했습니다.
 - 캡처 데이터 초기화를 위한 유틸 함수(resetCapturedSteps)를 추가했습니다.

## 💬 리뷰 요청 사항

캡처 상태 유지 및 초기화 로직이 의도대로 동작하는지 확인 부탁드립니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
