### PR TITLE
refactor: 캡쳐 상태 표시 UI 컴포넌트 분리 및 스타일 조정 (#63)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/TaskStatusHeader.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskStatusHeader.jsx
@@ -1,0 +1,20 @@
+const TaskStatusHeader = ({ isCapturing }) => {
+  return (
+    <div className="flex justify-around bg-orange-500 py-3 text-white">
+      <div className="flex flex-col items-center">
+        {isCapturing ? (
+          <div className="flex items-center justify-center">
+            <div className="flex h-10 w-10 items-center justify-center bg-white">
+              <div className="flex h-5 w-5 animate-pulse rounded-full bg-orange-500" />
+            </div>
+            <div className="ml-3 flex animate-pulse text-2xl text-white">캡쳐중...</div>
+          </div>
+        ) : (
+          <div className="ml-3 flex text-2xl text-white">캡쳐 일시중단</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskStatusHeader;

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -9,6 +9,7 @@ import WarningModal from "@/sidepanel/components/WarningModal";
 import { getCaptureStatus, resetCapturedSteps } from "@/utils/storage";
 
 import TaskCard from "./TaskCard";
+import TaskStatusHeader from "./TaskStatusHeader";
 
 const TaskBoard = () => {
   const navigate = useNavigate();
@@ -130,20 +131,8 @@ const TaskBoard = () => {
           onClose={() => setShowModal(false)}
         />
       )}
-      <div className="flex justify-around bg-orange-500 py-4 text-white">
-        <div className="flex flex-col items-center">
-          {isCapturing ? (
-            <div className="flex items-center justify-center">
-              <div className="flex h-12 w-12 items-center justify-center bg-white">
-                <div className="flex h-6 w-6 animate-pulse rounded-full bg-orange-500" />
-              </div>
-              <div className="ml-3 flex animate-pulse text-3xl text-white">캡쳐중...</div>
-            </div>
-          ) : (
-            <div className="ml-3 flex text-3xl text-white">캡쳐 일시중단</div>
-          )}
-        </div>
-      </div>
+
+      <TaskStatusHeader isCapturing={isCapturing} />
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {steps.length === 0 ? (


### PR DESCRIPTION
## #️⃣ Issue Number #63 

## 📝 세부 내용

기존 TaskBoard.jsx 내에 있던 캡쳐 상태 표시 UI를 TaskStatusHeader.jsx로 분리했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
