### PR TITLE
refactor: TaskBoard 하단 제어 UI 컴포넌트 분리 (#65)

### DIFF
--- a/src/sidepanel/pages/TaskBoard/TaskControlBar.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskControlBar.jsx
@@ -1,0 +1,37 @@
+const TaskControlBar = ({ isCapturing, onFinishClick, onPauseClick, onCleanupClick }) => {
+  return (
+    <div className="flex justify-around bg-orange-500 py-4 text-white">
+      <div className="flex flex-col items-center">
+        <button
+          className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+          onClick={onFinishClick}
+        >
+          ✓
+        </button>
+        <span className="mt-1 text-sm">캡쳐완료</span>
+      </div>
+
+      <div className="flex flex-col items-center">
+        <button
+          className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+          onClick={onPauseClick}
+        >
+          {isCapturing ? "ǁ" : <div className="ml-[2px]">▶</div>}
+        </button>
+        <span className="mt-1 text-sm">{isCapturing ? "일시중지" : "캡쳐 계속진행"}</span>
+      </div>
+
+      <div className="flex flex-col items-center">
+        <button
+          className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
+          onClick={onCleanupClick}
+        >
+          ✕
+        </button>
+        <span className="mt-1 text-sm">끄기</span>
+      </div>
+    </div>
+  );
+};
+
+export default TaskControlBar;

--- a/src/sidepanel/pages/TaskBoard/TaskStatusHeader.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskStatusHeader.jsx
@@ -1,0 +1,20 @@
+const TaskStatusHeader = ({ isCapturing }) => {
+  return (
+    <div className="flex justify-around bg-orange-500 py-3 text-white">
+      <div className="flex flex-col items-center">
+        {isCapturing ? (
+          <div className="flex items-center justify-center">
+            <div className="flex h-10 w-10 items-center justify-center bg-white">
+              <div className="flex h-5 w-5 animate-pulse rounded-full bg-orange-500" />
+            </div>
+            <div className="ml-3 flex animate-pulse text-2xl text-white">캡쳐중...</div>
+          </div>
+        ) : (
+          <div className="ml-3 flex text-2xl text-white">캡쳐 일시중단</div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default TaskStatusHeader;

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -9,6 +9,7 @@ import WarningModal from "@/sidepanel/components/WarningModal";
 import { getCaptureStatus, resetCapturedSteps } from "@/utils/storage";
 
 import TaskCard from "./TaskCard";
+import TaskStatusHeader from "./TaskStatusHeader";
 
 const TaskBoard = () => {
   const navigate = useNavigate();
@@ -130,20 +131,8 @@ const TaskBoard = () => {
           onClose={() => setShowModal(false)}
         />
       )}
-      <div className="flex justify-around bg-orange-500 py-4 text-white">
-        <div className="flex flex-col items-center">
-          {isCapturing ? (
-            <div className="flex items-center justify-center">
-              <div className="flex h-12 w-12 items-center justify-center bg-white">
-                <div className="flex h-6 w-6 animate-pulse rounded-full bg-orange-500" />
-              </div>
-              <div className="ml-3 flex animate-pulse text-3xl text-white">캡쳐중...</div>
-            </div>
-          ) : (
-            <div className="ml-3 flex text-3xl text-white">캡쳐 일시중단</div>
-          )}
-        </div>
-      </div>
+
+      <TaskStatusHeader isCapturing={isCapturing} />
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-6">
         {steps.length === 0 ? (

--- a/src/sidepanel/pages/TaskBoard/index.jsx
+++ b/src/sidepanel/pages/TaskBoard/index.jsx
@@ -9,6 +9,7 @@ import WarningModal from "@/sidepanel/components/WarningModal";
 import { getCaptureStatus, resetCapturedSteps } from "@/utils/storage";
 
 import TaskCard from "./TaskCard";
+import TaskControlBar from "./TaskControlBar";
 import TaskStatusHeader from "./TaskStatusHeader";
 
 const TaskBoard = () => {
@@ -163,37 +164,12 @@ const TaskBoard = () => {
         )}
       </div>
 
-      <div className="flex justify-around bg-orange-500 py-4 text-white">
-        <div className="flex flex-col items-center">
-          <button
-            className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-            onClick={handleFinishClick}
-          >
-            ✓
-          </button>
-          <span className="mt-1 text-sm">캡쳐완료</span>
-        </div>
-
-        <div className="flex flex-col items-center">
-          <button
-            className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-            onClick={handlePauseClick}
-          >
-            {isCapturing ? "ǁ" : <div className="ml-[2px]">▶</div>}
-          </button>
-          <span className="mt-1 text-sm">{isCapturing ? "일시중지" : "캡쳐 계속진행"}</span>
-        </div>
-
-        <div className="flex flex-col items-center">
-          <button
-            className="flex h-12 w-12 cursor-pointer items-center justify-center rounded-full bg-white text-2xl font-bold text-orange-500 hover:bg-gray-200 hover:text-3xl"
-            onClick={handleCleanupClick}
-          >
-            ✕
-          </button>
-          <span className="mt-1 text-sm">끄기</span>
-        </div>
-      </div>
+      <TaskControlBar
+        isCapturing={isCapturing}
+        onFinishClick={handleFinishClick}
+        onPauseClick={handlePauseClick}
+        onCleanupClick={handleCleanupClick}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## #️⃣ Issue Number #65 


## 📝 세부 내용

- TaskBoard 컴포넌트 내 하단 제어 버튼 영역을 TaskControlBar 컴포넌트로 분리했습니다.

## 💬 리뷰 요청 사항

<!-- 리뷰어에게 확인받고 싶은 부분이나 논의가 필요한 내용을 작성해주세요. -->

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
