### PR TITLE
refactor: TaskBoard의 핸들러 함수 커스텀훅(useTaskHandlers.js)으로 분리 (#69)

### DIFF
--- a/src/hooks/useTaskHandlers.jsx
+++ b/src/hooks/useTaskHandlers.jsx
@@ -1,0 +1,80 @@
+import { useNavigate } from "react-router-dom";
+
+import createManual from "@/api/createManual";
+import { resetCapturedSteps } from "@/utils/storage";
+import { getCaptureStatus } from "@/utils/storage";
+
+const useTaskHandlers = ({ steps, setSteps, setIsCapturing, setIsLoading, setShowModal }) => {
+  const navigate = useNavigate();
+  const goToMain = () => {
+    navigate("/");
+  };
+  const handleTitleChange = (index, newTitle) => {
+    setSteps((prev) => {
+      const updated = [...prev];
+      updated[index].elementData.textContent = newTitle;
+
+      chrome.storage.local.set({ CapturedSteps: updated });
+      return updated;
+    });
+  };
+  const handleDeleteStep = (taskId) => {
+    setSteps((prev) => {
+      const updatedSteps = prev.filter((step) => step.id !== taskId);
+      chrome.storage.local.set({ CapturedSteps: updatedSteps });
+      return updatedSteps;
+    });
+  };
+  const handlePauseClick = () => {
+    setIsCapturing((prev) => {
+      chrome.storage.local.set({ isCapturing: !prev });
+      return !prev;
+    });
+  };
+  const handleFinishClick = async () => {
+    const stepData = steps.map((step) => ({
+      text: step.elementData.textContent,
+      image: step.image,
+    }));
+    const body = {
+      steps: stepData,
+    };
+
+    setIsLoading(true);
+    try {
+      await createManual(body);
+      resetCapturedSteps();
+      navigate("/repository");
+    } catch (error) {
+      console.error("매뉴얼 생성 에러:", error);
+      setShowModal(true);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  const handleCleanupClick = async () => {
+    chrome.runtime.sendMessage({ type: "CLEANUP_ALL" }, async () => {
+      if (chrome.runtime.lastError) {
+        console.error("CLEANUP_ALL 전송 오류:", chrome.runtime.lastError.message);
+      } else {
+        console.log("📨 CLEANUP_ALL 메시지 전송됨");
+        await chrome.storage.local.set({ isCapturing: false });
+
+        const status = await getCaptureStatus();
+        setIsCapturing(status);
+        resetCapturedSteps();
+        goToMain();
+      }
+    });
+  };
+
+  return {
+    handleTitleChange,
+    handleDeleteStep,
+    handlePauseClick,
+    handleFinishClick,
+    handleCleanupClick,
+  };
+};
+
+export default useTaskHandlers;


### PR DESCRIPTION
## #️⃣ Issue Number #69 

## 📝 세부 내용

TaskBoard 컴포넌트에서 이벤트 핸들링 관련 로직이 많아짐에 따라, 코드 가독성과 유지보수를 개선하기 위해 관련 핸들러들을 별도의 커스텀 훅(useTaskHandlers.js)으로 분리했습니다.


## 💬 리뷰 요청 사항

useTaskHandlers.js 내 함수 분리 구조가 적절한지

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
