### PR TITLE
feat: 회원 탈퇴 버튼 클릭 시 탈퇴 API 호출 구현 (#70)

### DIFF
--- a/src/sidepanel/pages/Login/LoginPopup/index.jsx
+++ b/src/sidepanel/pages/Login/LoginPopup/index.jsx
@@ -10,27 +10,29 @@ const LoginPopup = () => {
   const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
-    const urlParams = new URLSearchParams(window.location.search);
-    const code = urlParams.get("code");
+    const handleLogin = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const code = urlParams.get("code");
 
-    if (code) {
-      axios
-        .post(
+      if (!code) return;
+      try {
+        const res = await axios.post(
           `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/auth/kakao/login`,
           { code },
           { withCredentials: true },
-        )
-        .then((res) => {
-          const { token } = res.data;
-          if (token) {
-            window.opener.postMessage({ token }, "*");
-            window.close();
-          }
-        })
-        .catch(() => {
-          setShowModal(true);
-        });
-    }
+        );
+
+        const { token } = res.data;
+        if (token) {
+          window.opener.postMessage({ token }, "*");
+          window.close();
+        }
+      } catch {
+        setShowModal(true);
+      }
+    };
+
+    handleLogin();
   }, []);
 
   return (

--- a/src/sidepanel/pages/MainPage/index.jsx
+++ b/src/sidepanel/pages/MainPage/index.jsx
@@ -13,16 +13,12 @@ const MainPage = () => {
     navigate("/taskboard");
   };
 
-  const handleLogoutAndClose = () => {
+  const handleLogoutAndClose = async () => {
     const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken) return;
 
-    if (!accessToken) {
-      alert("Access Token이 없습니다.");
-      return;
-    }
-
-    axios
-      .post(
+    try {
+      await axios.post(
         `${import.meta.env.VITE_BACKEND_SERVER_URL}/api/auth/kakao/logout`,
         {},
         {
@@ -31,14 +27,13 @@ const MainPage = () => {
           },
           withCredentials: true,
         },
-      )
-      .then(() => {
-        localStorage.removeItem("accessToken");
-        window.close();
-      })
-      .catch(() => {
-        setShowModal(true);
-      });
+      );
+
+      localStorage.removeItem("accessToken");
+      window.close();
+    } catch {
+      setShowModal(true);
+    }
   };
 
   return (

--- a/src/sidepanel/pages/Settings/DeleteAccount/index.jsx
+++ b/src/sidepanel/pages/Settings/DeleteAccount/index.jsx
@@ -1,50 +1,82 @@
 import "@/styles/styles.css";
+import axios from "axios";
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import BackButton from "@/sidepanel/components/BackButton";
+import WarningModal from "@/sidepanel/components/WarningModal";
 
 const DeleteAccount = () => {
   const [agree, setAgree] = useState(false);
+  const [showModal, setShowModal] = useState(false);
   const navigate = useNavigate();
 
+  const handleDeleteAccount = async () => {
+    const accessToken = localStorage.getItem("accessToken");
+
+    try {
+      await axios.delete(`${import.meta.env.VITE_BACKEND_SERVER_URL}/api/users/me`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        withCredentials: true,
+      });
+
+      localStorage.removeItem("accessToken");
+      navigate("/noticedeleteaccount");
+    } catch {
+      setShowModal(true);
+    }
+  };
+
   return (
-    <div className="main-container">
-      <div className="flex min-h-screen flex-col bg-white">
-        <div className="flex items-center bg-orange-500 px-4 py-3">
-          <BackButton />
-          <h1 className="text-lg font-bold text-white">탈퇴하기</h1>
-        </div>
+    <>
+      <div className="main-container">
+        <div className="flex min-h-screen flex-col bg-white">
+          <div className="flex items-center bg-orange-500 px-4 py-3">
+            <BackButton />
+            <h1 className="text-lg font-bold text-white">탈퇴하기</h1>
+          </div>
 
-        <div className="mt-20 flex flex-col items-center">
-          <div className="w-64 rounded-xl bg-gray-200 px-4 py-6 text-center">
-            <p className="mb-2 text-xl font-bold text-stone-900">공지사항</p>
-            <p className="mb-4 text-sm text-stone-700">...............</p>
+          <div className="mt-20 flex flex-col items-center">
+            <div className="w-64 rounded-xl bg-gray-200 px-4 py-6 text-center">
+              <p className="mb-2 text-xl font-bold text-stone-900">공지사항</p>
+              <p className="mb-4 text-sm text-stone-700">...............</p>
 
-            <div className="mb-4 text-sm font-bold text-stone-900">
-              <label className="text-sm">
-                <input
-                  type="checkbox"
-                  className="mr-2"
-                  checked={agree}
-                  onChange={() => setAgree(!agree)}
-                />
-                안내사항에 동의합니다.
-              </label>
+              <div className="mb-4 text-sm font-bold text-stone-900">
+                <label className="text-sm">
+                  <input
+                    type="checkbox"
+                    className="mr-2"
+                    checked={agree}
+                    onChange={() => setAgree(!agree)}
+                  />
+                  안내사항에 동의합니다.
+                </label>
+              </div>
+
+              <button
+                className={`w-full rounded-xl py-3 font-bold text-white ${
+                  agree ? "bg-gray-700 hover:bg-gray-800" : "bg-gray-400"
+                }`}
+                disabled={!agree}
+                onClick={handleDeleteAccount}
+              >
+                탈 퇴 하 기
+              </button>
             </div>
-
-            <button
-              className={`w-full rounded-xl py-3 font-bold text-white ${
-                agree ? "bg-gray-700 hover:bg-gray-800" : "bg-gray-400"
-              }`}
-              onClick={agree ? () => navigate("/noticedeleteaccount") : undefined}
-            >
-              탈 퇴 하 기
-            </button>
           </div>
         </div>
       </div>
-    </div>
+
+      {showModal && (
+        <WarningModal
+          title="회원탈퇴 실패"
+          message="회원탈퇴 중 오류가 발생했습니다."
+          onClose={() => setShowModal(false)}
+        />
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## #️⃣ Issue Number #70

## 📝 세부 내용

- 회원 탈퇴 기능을 구현하고, 기존 Promise 기반 로직을 async/await + try/catch 구조로 리팩토링했습니다.
- 회원 탈퇴 버튼 클릭 시 백엔드 `/api/users/me`로 DELETE 요청을 보내도록 연결했습니다.,

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.