### PR TITLE
feat: 초기 캡처 단계 문구 정리 및 길이 제한 추가 (#77)

### DIFF
--- a/src/background/backgroundUtils.js
+++ b/src/background/backgroundUtils.js
@@ -72,6 +72,20 @@ export const sendColor = (colorData) => {
 };
 
 export const captureAndStoreStep = (elementData, sendResponse) => {
+  const rawText = elementData.textContent?.trim() || "여기";
+
+  const maxLen = 13;
+  let processedText = rawText;
+  if (rawText.length > maxLen) {
+    processedText = rawText.slice(0, maxLen) + "...";
+  }
+
+  if (!processedText.endsWith("를 클릭했습니다")) {
+    processedText = `"${processedText}"를 클릭했습니다`;
+  }
+
+  const newElementData = { ...elementData, textContent: processedText };
+
   chrome.tabs.captureVisibleTab(null, { format: "png" }, (dataUrl) => {
     chrome.storage.local.get("CapturedSteps", (result) => {
       const currentSteps = Array.isArray(result.CapturedSteps) ? result.CapturedSteps : [];
@@ -80,7 +94,7 @@ export const captureAndStoreStep = (elementData, sendResponse) => {
         ...currentSteps,
         {
           image: dataUrl,
-          elementData,
+          elementData: newElementData,
         },
       ];
 

--- a/src/sidepanel/pages/TaskBoard/TaskCard.jsx
+++ b/src/sidepanel/pages/TaskBoard/TaskCard.jsx
@@ -51,9 +51,7 @@ const TaskCard = ({ index, element, image, onTitleChange, onDeleteStep }) => {
               className="cursor-pointer font-bold"
               onDoubleClick={handleDoubleClick}
             >
-              {inputValue?.trim()
-                ? `"${inputValue.trim().substring(0, 13)}"를 클릭해주세요`
-                : `"여기"를 클릭해주세요!!`}
+              {inputValue || `"여기"를 클릭해주세요!!`}
             </div>
           )}
         </div>


### PR DESCRIPTION
## #️⃣ Issue Number #77 


## 📝 세부 내용

- 사용자가 요소명을 편집한 후에도 "요소명"를 클릭했습니다 꼬리말이 계속 덧붙는 문제를 수정했습니다.
- TaskCard의 inputValue를 초기 렌더링에서만 가공하도록 변경하고, 사용자의 수정 내용은 있는 그대로 유지되도록 로직을 개선했습니다.
- background.js의 captureAndStoreStep 함수에서 최초 저장 시에만 "요소명"를 클릭했습니다 포맷을 적용하도록 수정하여, 불필요한 중복 포맷팅을 방지했습니다.
- 표시되는 텍스트 길이를 13자로 제한하여 UI 가독성을 높였습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
