### PR TITLE
fix: 캡처 완료 후 저장소 페이지로 이동되지 않던 문제 수정 (#79)

### DIFF
--- a/src/hooks/useTaskHandlers.jsx
+++ b/src/hooks/useTaskHandlers.jsx
@@ -43,6 +43,10 @@ const useTaskHandlers = ({ steps, setSteps, setIsCapturing, setIsLoading, setSho
     setIsLoading(true);
     try {
       await createManual(body);
+      await chrome.storage.local.set({ isCapturing: false });
+
+      const status = await getCaptureStatus();
+      setIsCapturing(status);
       resetCapturedSteps();
       navigate("/repository");
     } catch (error) {


### PR DESCRIPTION
## #️⃣ Issue Number #79 


## 📝 세부 내용

- 매뉴얼 캡처 완료 후 navigate('/repository')가 정상 작동하지 않아 저장소 페이지로 이동되지 않는 버그가 있었습니다.
- 비동기 처리 순서를 조정하여 캡처 완료 이후 저장소 페이지로 올바르게 이동되도록 수정했습니다.
- 관련 상태 초기화 (resetCapturedSteps, setIsCapturing)도 정상 반영되도록 정리했습니다.

## ✅ 체크리스트

- [x] 커밋 메시지 컨벤션을 지켰습니다 (`feat:`, `fix:`, `chore:` 등).
- [x] 관련 기능/버그에 대해 테스트를 완료했습니다.
- [x] 코드 스타일 가이드에 맞게 작성했습니다.
